### PR TITLE
Fix bug that you could get the coin with "remove coin from well"

### DIFF
--- a/calypso.inf
+++ b/calypso.inf
@@ -1190,7 +1190,10 @@ Object -> -> beer_glass "beer glass"
 Object  coin "silver coin",
  with   name 'silver' 'coin' 'money',
         before [;
-         Take: if (self in well)
+         Examine:
+		  	rfalse;
+		default:
+		 if (self in well)
          {
              "You cannot reach it!";
          }


### PR DESCRIPTION
Also, you could turn coin, push coin etc in the well. Now, only Examine works on the coin in the well.